### PR TITLE
Generate sample vcf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 env/
 __pycache__
+cache/
+data/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ To install dependencies run:
 ```
 pip install -r requirements.txt
 ```
+The `bcftools` executable must be in the PATH for generating the VCF files.
+Please refer to the [Samtools web page](http://www.htslib.org/download/) for installation instruction.
+
 
 #### Usage:
 
@@ -27,7 +30,14 @@ Generate phenopackets metadata:
 python samples_to_phenopackets.py
 ```
 
-Generate experiments metadata linked to the sample ids:
+Generate VCF files from 1000 genomes chromosome 22.
+```
+sh sample.vcf.sh
+```
+
+Generate experiments metadata linked to the sample ids and the VCF files
+if they are present in the `data` directory. When no VCF file matching the
+sample ID is present, a random hash is generated and appended to the filename.
 
 ```
 python generate_experiments.py

--- a/generate_experiments.py
+++ b/generate_experiments.py
@@ -3,9 +3,13 @@
 import json
 import random
 import uuid
+from glob import glob
+from os.path import basename
 
 from utils import generic_random_choices
 from controlled_vocabularies import *
+
+DATA_DIR = "./data"
 
 
 def single_experiment_result(sample_id, file_format):
@@ -19,9 +23,15 @@ def single_experiment_result(sample_id, file_format):
         }
     }
     if file_format == "VCF":
+        filename = f"{sample_id}_{uuid.uuid4()}.vcf.gz"
+        # Replace the random filename with a genuine one if it exists
+        file_in_data = glob(f"{DATA_DIR}/{sample_id}-*")
+        if len(file_in_data):
+            filename = basename(file_in_data[0])
+
         experiment_result_vcf = {
             "description": "VCF file",
-            "filename": f"{sample_id}_{uuid.uuid4()}.vcf.gz",
+            "filename": filename,
             "file_format": "VCF",
             "data_output_type": "Derived data",
             "usage": "download",
@@ -101,7 +111,7 @@ def main():
                 experiments["experiments"].append(experiment)
 
     # save experiments to the file
-    with open(f"experiments.json", "w") as output:
+    with open("experiments.json", "w") as output:
         json.dump(experiments, output, indent=4)
 
     print(f"Created {len(experiments['experiments'])} experiments")

--- a/sample.vcf.sh
+++ b/sample.vcf.sh
@@ -1,0 +1,90 @@
+# Generate a set of VCF files from the 1000 genomes project
+# Each file corresponds to 1 individual (here also a sample) and the
+# filename is a catenation of the sample ID and file shecksum (using sha1)
+# To reduce VCF file size, the variants are filtered against the AF field value:
+# modify the AF_THRESHOLD value accordingly.
+
+# The VCF from 1000 genomes for Chromosome 22 (because it is small)
+ORIG_VCF=ALL.chr22.phase3_shapeit2_mvncall_integrated_v5b.20130502.genotypes.vcf.gz
+FILTERED_VCF=filtered.vcf
+AF_THRESHOLD=0.97
+CACHE_DIR=./cache
+DATA_DIR=./data
+
+check_prerequisites()
+{
+    # bcftools
+    if ! command -v bcftools &> /dev/null
+    then
+        echo "Error: bctools could not be found"
+        exit 1
+    fi
+
+    # compgen
+    if ! command -v compgen &> /dev/null
+    then
+        echo "Error: compgen utility could not be found"
+        exit 1
+    fi
+}
+
+download_orig_file()
+{
+    echo "Downloading Chr22 VCF from 1000 genomes project"
+    if [ -f "${CACHE_DIR}/${ORIG_VCF}" ]; then 
+        echo "Using Chr22 VCF file from cache."
+        return 0 
+    fi
+
+    curl -v "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/${ORIG_VCF}" -o "${CACHE_DIR}/${ORIG_VCF}"
+}
+
+filter_vcf()
+{
+    echo "Generating a downsized filtered version of Chr22 VCF file. This may take a few minutes."
+    if [ -f "${CACHE_DIR}/${FILTERED_VCF}" ]; then 
+        echo "Using filtered VCF file from cache."
+        return 0; 
+    fi
+
+    bcftools view -i "AF>${AF_THRESHOLD}" "${CACHE_DIR}/${ORIG_VCF}" > "${CACHE_DIR}/${FILTERED_VCF}"
+}
+
+create_dirs()
+{
+    if [ ! -d $CACHE_DIR ]; then 
+        mkdir $CACHE_DIR
+    fi
+    if [ ! -d $DATA_DIR ]; then
+        mkdir $DATA_DIR
+    fi
+}
+
+
+check_prerequisites
+create_dirs 
+download_orig_file
+filter_vcf
+
+echo "Generating sample VCF files in ${DATA_DIR}"
+FILE="${CACHE_DIR}/${FILTERED_VCF}"
+SAMPLE_LIST=$(bcftools query -l $FILE)
+SAMPLE_NB=$(echo "${SAMPLE_LIST}" | wc -l | awk '{$1=$1};1')
+COUNT=0
+
+for sample in $SAMPLE_LIST; do
+    ((COUNT+=1))
+    printf "Generating VCF file ${COUNT} / ${SAMPLE_NB} \\r"
+
+    SAMPLE_FILE="${DATA_DIR}/${sample}.vcf.gz"
+    if compgen -G "${DATA_DIR}/${sample}-*.vcf.gz" > /dev/null; then
+        echo "VCF for ${sample} already exists."
+        continue
+    fi
+    bcftools view -c1 -Oz -s $sample -o $SAMPLE_FILE $FILE
+
+    # Rename file using hash from check sum
+    SHA=$(shasum $SAMPLE_FILE | head -c 40)
+    mv "${SAMPLE_FILE}" "${DATA_DIR}/${sample}-${SHA}.vcf.gz"
+done
+echo "${SAMPLE_NB} sample VCF files generated."


### PR DESCRIPTION
This PR adds the possibility to generate VCF files from 1000 genomes with deterministic filenames that are subsequently added into the experiment.json at generation time.

To test:
- follow the updated instructions in the README (mainly, run `sh sample.vcf.sh` before generating the experiment metadata)
- note that bcftools should be available on your system for processing the VCF files. An error message will be displayed in case it is found missing.
- check that the filenames for the vcf files in the file experiments.json match the ones from the `./data` repository