### PR TITLE
remove covid severity "dead"

### DIFF
--- a/dataset_files/config.json
+++ b/dataset_files/config.json
@@ -135,8 +135,7 @@
                     "Uninfected",
                     "Mild",
                     "Moderate",
-                    "Severe",
-                    "Dead"
+                    "Severe"
                 ]
             }
         },

--- a/phenopackets/extra_properties.py
+++ b/phenopackets/extra_properties.py
@@ -19,6 +19,5 @@ COVID_SEVERITY = [
     "Uninfected",
     "Mild",
     "Moderate",
-    "Severe",
-    "Dead"
+    "Severe"
 ]


### PR DESCRIPTION
Remove covid severity value "Dead", not especially meaningful ... perhaps you died in a car accident?