### PR TITLE
Update config

### DIFF
--- a/config/individuals.json
+++ b/config/individuals.json
@@ -6,7 +6,7 @@
             {
                 "id": "MS002001",
                 "sampled_tissue": {
-                    "id": "UBERON:0000955",
+                    "id": "UBERON:0013528",
                     "label": "Brodmann (1909) area 11"
                 },
                 "procedure": {

--- a/dataset_files/config.json
+++ b/dataset_files/config.json
@@ -154,7 +154,7 @@
       },
       "datatype": "string",
       "description": "ACMG Pathogenicity category for a particular variant (BENIGN, PATHOGENIC, etc)",
-      "mapping": "individual/phenopackets/interpretations/diagnosis/genomic_interpretations/variant_interpretation/acmg_pathogenicity_classification",
+      "mapping": "phenopacket/interpretations/diagnosis/genomic_interpretations/variant_interpretation/acmg_pathogenicity_classification",
       "title": "Variant Pathogenicity"
     },
     "active_record": {
@@ -190,7 +190,7 @@
       "description": "Body Mass Index",
       "group_by": "assay/id",
       "group_by_value": "NCIT:C16358",
-      "mapping": "individual/phenopackets/measurements",
+      "mapping": "phenopacket/measurements",
       "title": "BMI",
       "value_mapping": "value/quantity/value"
     },
@@ -227,7 +227,7 @@
       },
       "datatype": "string",
       "description": "Diseases observed as either present or absent",
-      "mapping": "individual/phenopackets/diseases/term/label",
+      "mapping": "phenopacket/diseases/term/label",
       "title": "Diseases"
     },
     "experiment_results_file_type": {
@@ -263,7 +263,7 @@
       },
       "datatype": "string",
       "description": "Interpretation for an individual variant or gene (CANDIDATE, CONTRIBUTORY, etc)",
-      "mapping": "individual/phenopackets/interpretations/diagnosis/genomic_interpretations/interpretation_status",
+      "mapping": "phenopacket/interpretations/diagnosis/genomic_interpretations/interpretation_status",
       "title": "Genomic Interpretations"
     },
     "lab_test_result_value": {
@@ -284,7 +284,7 @@
       "datatype": "string",
       "description": "A clinical procedure performed on a subject",
       "group_by": "procedure/code/label",
-      "mapping": "individual/phenopackets/medical_actions",
+      "mapping": "phenopacket/medical_actions",
       "title": "Medical Procedures"
     },
     "medical_treatments": {
@@ -294,7 +294,7 @@
       "datatype": "string",
       "description": "Treatment with an agent such as a drug",
       "group_by": "treatment/agent/label",
-      "mapping": "individual/phenopackets/medical_actions",
+      "mapping": "phenopacket/medical_actions",
       "title": "Medical Treatments"
     },
     "mobility": {
@@ -318,7 +318,7 @@
       },
       "datatype": "string",
       "description": "Individual phenotypic features, observed as either present or absent",
-      "mapping": "individual/phenopackets/phenotypic_features/pftype/label",
+      "mapping": "phenopacket/phenotypic_features/pftype/label",
       "title": "Phenotypic Features"
     },
     "sex": {

--- a/dataset_files/config.json
+++ b/dataset_files/config.json
@@ -1,251 +1,371 @@
 {
-    "overview": [
+  "overview": [
+    {
+      "section_title": "General",
+      "charts": [
         {
-            "section_title": "Demographics",
-            "charts": [
-                {
-                    "field": "age",
-                    "chart_type": "histogram"
-                },
-                {
-                    "field": "sex",
-                    "chart_type": "pie"
-                },
-                {
-                    "field": "vital_status",
-                    "chart_type": "bar"
-                },
-                {
-                    "field": "cause_of_death",
-                    "chart_type": "bar"
-                },
-                {
-                    "field": "covid_severity",
-                    "chart_type": "pie"
-                },
-                {
-                    "field": "date_of_consent",
-                    "chart_type": "histogram"
-                },
-                {
-                    "field": "mobility",
-                    "chart_type": "histogram"
-                },
-                {
-                    "field": "smoking_status",
-                    "chart_type": "bar"
-                }
-            ]
+          "field": "age",
+          "chart_type": "histogram"
         },
         {
-            "section_title": "Lab results and treatments",
-            "charts": [
-                {
-                    "field": "lab_test_result_value",
-                    "chart_type": "histogram"
-                },
-                {
-                    "field": "treatment_agent",
-                    "chart_type": "bar"
-                }
-            ]
+          "field": "sex",
+          "chart_type": "pie"
         },
         {
-            "section_title": "Experiments",
-            "charts": [
-                {
-                    "field": "experiment_type",
-                    "chart_type": "pie"
-                }
-            ]
+          "field": "vital_status",
+          "chart_type": "bar"
         },
         {
-            "section_title": "Other",
-            "charts": [
-                {
-                    "field": "active_record",
-                    "chart_type": "bar"
-                }
-            ]
+          "field": "cause_of_death",
+          "chart_type": "bar"
+        },
+        {
+          "field": "covid_severity",
+          "chart_type": "pie"
+        },
+        {
+          "field": "date_of_consent",
+          "chart_type": "histogram"
+        },
+        {
+          "field": "mobility",
+          "chart_type": "histogram"
+        },
+        {
+          "field": "smoking_status",
+          "chart_type": "bar"
+        },
+        {
+          "field": "phenotypic_features",
+          "chart_type": "pie"
+        },
+        {
+          "field": "tissues",
+          "chart_type": "pie"
+        },
+        {
+          "field": "diseases",
+          "chart_type": "pie"
         }
-    ],
-    "search": [
-        {
-            "section_title": "Demographics",
-            "fields": [
-                "age",
-                "sex",
-                "vital_status",
-                "cause_of_death",
-                "date_of_consent",
-                "mobility",
-                "covid_severity"
-            ]
-        },
-        {
-            "section_title": "Lab results and treatments",
-            "fields": [
-                "lab_test_result_value",
-                "treatment_agent"
-            ]
-        },
-        {
-            "section_title": "Experiments",
-            "fields": [
-                "experiment_type"
-            ]
-        },
-        {
-            "section_title": "Other",
-            "fields": [
-                "active_record"
-            ]
-        }
-    ],
-    "fields": {
-        "age": {
-            "mapping": "individual/age_numeric",
-            "title": "Age",
-            "description": "Age at arrival",
-            "datatype": "number",
-            "config": {
-                "bin_size": 10,
-                "taper_left": 10,
-                "taper_right": 100,
-                "units": "years",
-                "minimum": 0,
-                "maximum": 100
-            }
-        },
-        "sex": {
-            "mapping": "individual/sex",
-            "title": "Sex",
-            "description": "Sex at birth",
-            "datatype": "string",
-            "config": {
-                "enum": null
-            }
-        },
-        "vital_status": {
-            "mapping": "individual/vital_status/status",
-            "title": "Vital Status",
-            "description": "Vital status of the individual (alive/deceased/unknown)",
-            "datatype": "string",
-            "config": {
-                "enum": ["ALIVE", "DECEASED", "UNKNOWN_STATUS"]
-            }
-        },
-        "cause_of_death": {
-          "mapping": "individual/vital_status/cause_of_death/label",
-          "title": "Cause of Death",
-          "description": "Cause of death for individuals who are deceased",
-          "datatype": "string",
-          "config": {
-            "enum": null
-          }
-        },
-        "date_of_consent": {
-            "mapping": "individual/extra_properties/date_of_consent",
-            "title": "Verbal consent date",
-            "description": "Date of initial verbal consent(participant, legal representative or tutor), yyyy-mm-dd",
-            "datatype": "date",
-            "config": {
-                "bin_by": "month"
-            }
-        },
-        "mobility": {
-            "mapping": "individual/extra_properties/mobility",
-            "title": "Functional status",
-            "description": "Mobility",
-            "datatype": "string",
-            "config": {
-                "enum": [
-                    "I have no problems in walking about",
-                    "I have slight problems in walking about",
-                    "I have moderate problems in walking about",
-                    "I have severe problems in walking about",
-                    "I am unable to walk about"
-                ]
-            }
-        },
-        "smoking_status": {
-            "mapping": "individual/extra_properties/smoking_status",
-            "title": "Smoking status",
-            "description": "Smoking status",
-            "datatype": "string",
-            "config": {
-                "enum": [
-                    "Non-smoker",
-                    "Smoker",
-                    "Former smoker",
-                    "Passive smoker",
-                    "Not specified"
-                ]
-            }
-        },
-        "covid_severity": {
-            "mapping": "individual/extra_properties/covid_severity",
-            "title": "Covid severity",
-            "description": "Covid severity",
-            "datatype": "string",
-            "config": {
-                "enum": [
-                    "Uninfected",
-                    "Mild",
-                    "Moderate",
-                    "Severe"
-                ]
-            }
-        },
-        "lab_test_result_value": {
-            "mapping": "individual/extra_properties/lab_test_result_value",
-            "title": "Lab Test Result",
-            "description": "This acts as a placeholder for numeric values",
-            "datatype": "number",
-            "config": {
-                "bins": [
-                    200,
-                    300,
-                    500,
-                    1000,
-                    1500,
-                    2000
-                ],
-                "minimum": 0,
-                "units": "mg/L"
-            }
-        },
-        "treatment_agent": {
-            "mapping": "individual/phenopackets/medical_actions",
-            "group_by": "treatment/agent/label",
-            "title": "Medical Treatment Agents",
-            "description": "Treatment with an agent such as a drug",
-            "datatype": "string",
-            "config": {
-                "enum": null
-            }
-        },
-        "experiment_type": {
-            "mapping": "experiment/experiment_type",
-            "title": "Experiment Types",
-            "description": "Types of experiments performed on a sample",
-            "datatype": "string",
-            "config": {
-                "enum": null
-            }
-        },
-        "active_record": {
-            "mapping": "phenopacket/extra_properties/active_record",
-            "title": "Active Record?",
-            "description": "Whether this record is still active in the study",
-            "datatype": "string",
-            "config": {
-                "enum": ["Yes", "No"]
-            }
-        }
+      ]
     },
-    "rules": {
-        "count_threshold": 3,
-        "max_query_parameters": 2
+    {
+      "section_title": "Measurements",
+      "charts": [
+        {
+          "field": "lab_test_result_value",
+          "chart_type": "histogram"
+        },
+        {
+          "field": "bmi",
+          "chart_type": "histogram"
+        }
+      ]
+    },
+    {
+      "section_title": "Medical Actions",
+      "charts": [
+        {
+          "field": "medical_procedures",
+          "chart_type": "pie"
+        },
+        {
+          "field": "medical_treatments",
+          "chart_type": "pie"
+        }
+      ]
+    },
+    {
+      "section_title": "Interpretations",
+      "charts": [
+        {
+          "field": "interpretation_status",
+          "chart_type": "pie"
+        },
+        {
+          "field": "acmg_pathogenicity_classification",
+          "chart_type": "pie"
+        }
+      ]
+    },
+    {
+      "section_title": "Experiments",
+      "charts": [
+        {
+          "field": "experiment_type",
+          "chart_type": "pie"
+        },
+        {
+          "field": "experiment_study_type",
+          "chart_type": "pie"
+        },
+        {
+          "field": "experiment_results_file_type",
+          "chart_type": "pie"
+        }
+      ]
     }
+  ],
+  "search": [
+    {
+      "section_title": "General",
+      "fields": [
+        "age",
+        "sex",
+        "vital_status",
+        "cause_of_death",
+        "date_of_consent",
+        "mobility",
+        "covid_severity",
+        "phenotypic_features",
+        "diseases",
+        "tissues"
+      ]
+    },
+    {
+      "section_title": "Measurements",
+      "fields": ["lab_test_result_value", "bmi"]
+    },
+    {
+      "section_title": "Medical Actions",
+      "fields": ["medical_procedures", "medical_treatments"]
+    },
+    {
+      "section_title": "Interpretations",
+      "fields": ["interpretation_status", "acmg_pathogenicity_classification"]
+    },
+    {
+      "section_title": "Experiments",
+      "fields": [
+        "experiment_type",
+        "experiment_study_type",
+        "experiment_results_file_type"
+      ]
+    },
+    {
+      "section_title": "Other",
+      "fields": ["active_record"]
+    }
+  ],
+  "fields": {
+    "acmg_pathogenicity_classification": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "ACMG Pathogenicity category for a particular variant (BENIGN, PATHOGENIC, etc)",
+      "mapping": "individual/phenopackets/interpretations/diagnosis/genomic_interpretations/variant_interpretation/acmg_pathogenicity_classification",
+      "title": "Variant Pathogenicity"
+    },
+    "active_record": {
+      "config": {
+        "enum": ["Yes", "No"]
+      },
+      "datatype": "string",
+      "description": "Whether this record is still active in the study",
+      "mapping": "phenopacket/extra_properties/active_record",
+      "title": "Active Record?"
+    },
+    "age": {
+      "config": {
+        "bin_size": 10,
+        "maximum": 110,
+        "minimum": 0,
+        "taper_left": 10,
+        "taper_right": 100,
+        "units": "years"
+      },
+      "datatype": "number",
+      "description": "Age at arrival",
+      "mapping": "individual/age_numeric",
+      "title": "Age"
+    },
+    "bmi": {
+      "config": {
+        "bins": [18.5, 30],
+        "minimum": 0,
+        "units": "kg/m^2"
+      },
+      "datatype": "number",
+      "description": "Body Mass Index",
+      "group_by": "assay/id",
+      "group_by_value": "NCIT:C16358",
+      "mapping": "individual/phenopackets/measurements",
+      "title": "BMI",
+      "value_mapping": "value/quantity/value"
+    },
+    "cause_of_death": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Cause of death for individuals who are deceased",
+      "mapping": "individual/vital_status/cause_of_death/label",
+      "title": "Cause of Death"
+    },
+    "covid_severity": {
+      "config": {
+        "enum": ["Uninfected", "Mild", "Moderate", "Severe"]
+      },
+      "datatype": "string",
+      "description": "Covid severity",
+      "mapping": "individual/extra_properties/covid_severity",
+      "title": "Covid severity"
+    },
+    "date_of_consent": {
+      "config": {
+        "bin_by": "month"
+      },
+      "datatype": "date",
+      "description": "Date of initial verbal consent (participant, legal representative or tutor), yyyy-mm-dd",
+      "mapping": "individual/extra_properties/date_of_consent",
+      "title": "Verbal consent date"
+    },
+    "diseases": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Diseases observed as either present or absent",
+      "mapping": "individual/phenopackets/diseases/term/label",
+      "title": "Diseases"
+    },
+    "experiment_results_file_type": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "File type of experiment results files",
+      "mapping": "experiment/experiment_results/file_format",
+      "title": "Results File Types"
+    },
+    "experiment_study_type": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Study type of the experiment (e.g. Genomics, Transcriptomics, etc.)",
+      "mapping": "experiment/study_type",
+      "title": "Study Types"
+    },
+    "experiment_type": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Types of experiments performed on a sample",
+      "mapping": "experiment/experiment_type",
+      "title": "Experiment Types"
+    },
+    "interpretation_status": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Interpretation for an individual variant or gene (CANDIDATE, CONTRIBUTORY, etc)",
+      "mapping": "individual/phenopackets/interpretations/diagnosis/genomic_interpretations/interpretation_status",
+      "title": "Genomic Interpretations"
+    },
+    "lab_test_result_value": {
+      "config": {
+        "bins": [200, 300, 500, 1000, 1500, 2000],
+        "minimum": 0,
+        "units": "mg/L"
+      },
+      "datatype": "number",
+      "description": "Numeric measures from a laboratory test",
+      "mapping": "individual/extra_properties/lab_test_result_value",
+      "title": "Lab Test Result"
+    },
+    "medical_procedures": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "A clinical procedure performed on a subject",
+      "group_by": "procedure/code/label",
+      "mapping": "individual/phenopackets/medical_actions",
+      "title": "Medical Procedures"
+    },
+    "medical_treatments": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Treatment with an agent such as a drug",
+      "group_by": "treatment/agent/label",
+      "mapping": "individual/phenopackets/medical_actions",
+      "title": "Medical Treatments"
+    },
+    "mobility": {
+      "config": {
+        "enum": [
+          "I have no problems in walking about",
+          "I have slight problems in walking about",
+          "I have moderate problems in walking about",
+          "I have severe problems in walking about",
+          "I am unable to walk about"
+        ]
+      },
+      "datatype": "string",
+      "description": "Mobility",
+      "mapping": "individual/extra_properties/mobility",
+      "title": "Functional status"
+    },
+    "phenotypic_features": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Individual phenotypic features, observed as either present or absent",
+      "mapping": "individual/phenopackets/phenotypic_features/pftype/label",
+      "title": "Phenotypic Features"
+    },
+    "sex": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Sex at birth",
+      "mapping": "individual/sex",
+      "title": "Sex"
+    },
+    "smoking_status": {
+      "config": {
+        "enum": [
+          "Non-smoker",
+          "Smoker",
+          "Former smoker",
+          "Passive smoker",
+          "Not specified"
+        ]
+      },
+      "datatype": "string",
+      "description": "Smoking status",
+      "mapping": "individual/extra_properties/smoking_status",
+      "title": "Smoking status"
+    },
+    "tissues": {
+      "config": {
+        "enum": null
+      },
+      "datatype": "string",
+      "description": "Tissue from which the sample was taken",
+      "mapping": "biosample/sampled_tissue/label",
+      "title": "Sampled Tissues"
+    },
+    "vital_status": {
+      "config": {
+        "enum": ["ALIVE", "DECEASED", "UNKNOWN_STATUS"]
+      },
+      "datatype": "string",
+      "description": "Vital status of the individual (alive/deceased/unknown)",
+      "mapping": "individual/vital_status/status",
+      "title": "Vital Status"
+    }
+  },
+  "rules": {
+    "count_threshold": 3,
+    "max_query_parameters": 2
+  }
 }


### PR DESCRIPTION
Add new fields to search config:
- diseases
- phenotypic features
- interpretation_status
- more specific medical action fields 
- BMI (working correctly now that decimal search in correct)

... these were largely already being used in configs on staging and elsewhere, translations for them exist already in bento_public.

Also: 
- formatted the config json and alpha ordered the "fields" keys, there are too many of them now for the current random order
- fixed an ontology in the IHEC example 